### PR TITLE
fix customer persistor signatures

### DIFF
--- a/src/gjk/layout_lite_persistor.py
+++ b/src/gjk/layout_lite_persistor.py
@@ -188,23 +188,37 @@ class LayoutLitePersistor:
             ),
         )
 
-    def persist_v007(self, from_alias: str, layout: LayoutLite007):
+    def persist_v007(
+        self, from_alias: str, time_received: datetime, layout: LayoutLite007
+    ):
         return self.persist(from_alias, layout)
 
-    def persist_v008(self, from_alias: str, layout: LayoutLite008):
+    def persist_v008(
+        self, from_alias: str, time_received: datetime, layout: LayoutLite008
+    ):
         return self.persist(from_alias, layout)
 
-    def persist_v009(self, from_alias: str, layout: LayoutLite009):
+    def persist_v009(
+        self, from_alias: str, time_received: datetime, layout: LayoutLite009
+    ):
         return self.persist(from_alias, layout)
 
-    def persist_v010(self, from_alias: str, layout: LayoutLite010):
+    def persist_v010(
+        self, from_alias: str, time_received: datetime, layout: LayoutLite010
+    ):
         return self.persist(from_alias, layout)
 
-    def persist_v011(self, from_alias: str, layout: LayoutLite011):
+    def persist_v011(
+        self, from_alias: str, time_received: datetime, layout: LayoutLite011
+    ):
         return self.persist(from_alias, layout)
 
-    def persist_v012(self, from_alias: str, layout: LayoutLite012):
+    def persist_v012(
+        self, from_alias: str, time_received: datetime, layout: LayoutLite012
+    ):
         return self.persist(from_alias, layout)
 
-    def persist_v013(self, from_alias: str, layout: LayoutLite):
+    def persist_v013(
+        self, from_alias: str, time_received: datetime, layout: LayoutLite
+    ):
         return self.persist(from_alias, layout)

--- a/src/gjk/report_event_persistor.py
+++ b/src/gjk/report_event_persistor.py
@@ -1,7 +1,6 @@
 import hashlib
 import uuid
 from datetime import datetime, timezone
-from typing import List
 
 from gw_data.db.models import ReadingChannelSql, ReadingSql
 from sqlalchemy.dialects.postgresql import insert
@@ -188,7 +187,9 @@ class ReportEventPersistor:
             )
             db.execute(stmt, dicts)
 
-    def persist_v002(self, from_alias: str, report: ReportEvent002):
+    def persist_v002(
+        self, from_alias: str, time_received: datetime, report: ReportEvent002
+    ):
         return MessagePersistenceInfo(
             id=report.message_id,
             created_at=datetime.fromtimestamp(report.time_created_ms / 1000),
@@ -197,7 +198,9 @@ class ReportEventPersistor:
             ),
         )
 
-    def persist_v003(self, from_alias: str, report: ReportEvent):
+    def persist_v003(
+        self, from_alias: str, time_received: datetime, report: ReportEvent
+    ):
         return MessagePersistenceInfo(
             id=report.message_id,
             created_at=datetime.fromtimestamp(report.time_created_ms / 1000),

--- a/tests/test_custom_persistor_idempotency.py
+++ b/tests/test_custom_persistor_idempotency.py
@@ -9,13 +9,18 @@ threads time_received through to the custom persistor (the actual root cause).
 No DB/AWS.
 """
 
+import inspect
 import logging
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
+import pytest
+
 from gjk.flo_params_house0_persistor import FloParamsHouse0Persistor
+from gjk.layout_lite_persistor import LayoutLitePersistor
 from gjk.message_persistence_info import MessagePersistenceInfo, default_message_id
+from gjk.report_event_persistor import ReportEventPersistor
 from gjk.sema_message_persistor import SemaMessagePersistor
 from gjk.weather_forecast_persistor import WeatherForecastPersistor
 
@@ -81,3 +86,33 @@ def test_dispatch_threads_time_received_to_custom_persistor():
     p.persist_message(FROM_ALIAS, t, payload)
 
     custom.persist_v000.assert_called_once_with(FROM_ALIAS, t, payload)
+
+
+@pytest.mark.parametrize(
+    "persistor_cls",
+    [
+        FloParamsHouse0Persistor,
+        WeatherForecastPersistor,
+        ReportEventPersistor,
+        LayoutLitePersistor,
+    ],
+)
+def test_every_custom_persist_method_accepts_time_received(persistor_cls):
+    """Real-signature guard for the seam contract.
+
+    ``SemaMessagePersistor.persist_message`` calls every custom persistor as
+    ``persist_vNNN(from_alias, time_received, payload)``. The existing seam
+    test uses a MagicMock, so it cannot catch a real persistor whose
+    ``persist_vNNN`` was never migrated to take ``time_received`` (the
+    report.event / layout.lite regression). Assert each real method's third
+    positional parameter is ``time_received``.
+    """
+    methods = [m for m in dir(persistor_cls) if m.startswith("persist_v")]
+    assert methods, f"{persistor_cls.__name__} exposes no persist_vNNN methods"
+    for name in methods:
+        params = list(inspect.signature(getattr(persistor_cls, name)).parameters)
+        assert params[:3] == ["self", "from_alias", "time_received"], (
+            f"{persistor_cls.__name__}.{name}{tuple(params)} must accept "
+            "(self, from_alias, time_received, <payload>) — the dispatch seam "
+            "passes time_received positionally"
+        )


### PR DESCRIPTION
Hi Joe - heads up - I found a gap in the uuid5 idempotency change. This is a patch. Right now report.event and layout.lite are not getting the new signature and are dropping. I've added time_received to these methods. 

Merging this to patch the bug